### PR TITLE
Use 1e10 instead of 10000000000

### DIFF
--- a/PriceConverter.sol
+++ b/PriceConverter.sol
@@ -15,7 +15,7 @@ library PriceConverter {
         );
         (, int256 answer, , , ) = priceFeed.latestRoundData();
         // ETH/USD rate in 18 digit
-        return uint256(answer * 10000000000);
+        return uint256(answer * 1e10); // 1**10 == 10000000000
     }
 
     // 1000000000
@@ -25,7 +25,7 @@ library PriceConverter {
         returns (uint256)
     {
         uint256 ethPrice = getPrice();
-        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
+        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1e18; // 1 ** 18 == 1000000000000000000
         // the actual ETH/USD conversion rate, after adjusting the extra 0s.
         return ethAmountInUsd;
     }

--- a/PriceConverter.sol
+++ b/PriceConverter.sol
@@ -15,7 +15,9 @@ library PriceConverter {
         );
         (, int256 answer, , , ) = priceFeed.latestRoundData();
         // ETH/USD rate in 18 digit
-        return uint256(answer * 1e10); // 1* 10 ** 10 == 10000000000
+        return uint256(answer * 10000000000);
+        // or (Both will do the same thing)
+        // return uint256(answer * 1e10); // 1* 10 ** 10 == 10000000000
     }
 
     // 1000000000
@@ -25,7 +27,9 @@ library PriceConverter {
         returns (uint256)
     {
         uint256 ethPrice = getPrice();
-        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1e18; // 1 * 10 ** 18 == 1000000000000000000
+        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1000000000000000000;
+        // or (Both will do the same thing)
+        // uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1e18; // 1 * 10 ** 18 == 1000000000000000000
         // the actual ETH/USD conversion rate, after adjusting the extra 0s.
         return ethAmountInUsd;
     }

--- a/PriceConverter.sol
+++ b/PriceConverter.sol
@@ -15,7 +15,7 @@ library PriceConverter {
         );
         (, int256 answer, , , ) = priceFeed.latestRoundData();
         // ETH/USD rate in 18 digit
-        return uint256(answer * 1e10); // 1**10 == 10000000000
+        return uint256(answer * 1e10); // 1* 10 ** 10 == 10000000000
     }
 
     // 1000000000
@@ -25,7 +25,7 @@ library PriceConverter {
         returns (uint256)
     {
         uint256 ethPrice = getPrice();
-        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1e18; // 1 ** 18 == 1000000000000000000
+        uint256 ethAmountInUsd = (ethPrice * ethAmount) / 1e18; // 1 * 10 ** 18 == 1000000000000000000
         // the actual ETH/USD conversion rate, after adjusting the extra 0s.
         return ethAmountInUsd;
     }


### PR DESCRIPTION
In PriceConverter.sol smart contract. Use 1e10 instead of 10000000000 and  1e18 instead of 1000000000000000000 for better understanding and readability of code.